### PR TITLE
Prepare for Fable support

### DIFF
--- a/src/MarkerClustering/MarkerClustering.fsproj
+++ b/src/MarkerClustering/MarkerClustering.fsproj
@@ -21,7 +21,8 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/fsprojects/MarkerClustering</RepositoryUrl>
-
+    <PackageReleaseNotes>Add Fable support</PackageReleaseNotes>
+    
     <!-- SourceLink settings -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>	    
@@ -31,6 +32,10 @@
     <PackageReference Include="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
+  <ItemGroup>
+     <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
+  </ItemGroup>
+   
   <ItemGroup>
     <Compile Include="GeoClustering.fs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #2 by preparing the library for Fable support. You only need to pack and publish to nuget (I updated version and added release notes as well)